### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/nacl_encrypted_fields/__init__.py
+++ b/nacl_encrypted_fields/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 from nacl_encrypted_fields.fields import NaClFieldMixin  # noqa: F401


### PR DESCRIPTION
Bump version to 1.0.1.

## Changelog

- Update `field` to `nacl_encrypted_fields` by @arjenzijlstra 

## Release

Release this version to PyPi by tagging (`v1.0.1`) the merge commit created after accepting the pull request. Travis will automatically release the newly build version (on tags only) to PyPi.