### PR TITLE
Remove double b'' in management command

### DIFF
--- a/nacl_encrypted_fields/management/commands/createkey.py
+++ b/nacl_encrypted_fields/management/commands/createkey.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         key = NaClWrapper.createKey()
-        output = 'NACL_FIELDS_KEY = b\'%s\'' % key
+        output = 'NACL_FIELDS_KEY = %s' % key
 
         filename = options['filename']
         if filename:


### PR DESCRIPTION
In Python 3 an extra `b''` was surrounding the `NACL_FIELDS_KEY` on creation. Since Python 2 support can be dropped now,  the fix is easy.