### PR TITLE
Fix content-type of description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         ' using PyNaCl.'
     ),
     long_description=README,
+    long_description_content_type='text/markdown',
     url='https://github.com/poolvos/django-nacl-fields',
     author='Poolvos B.V.',
     author_email='info@poolvos.nl',


### PR DESCRIPTION
Set the content-type of the description in setup.py to `text/markdown` to allow correct rendering once #25 has been merged.

For more information about the description content type see: https://packaging.python.org/specifications/core-metadata/#description-content-type-optional